### PR TITLE
Add 31 historical deleted Casks

### DIFF
--- a/Casks/affinity-designer.rb
+++ b/Casks/affinity-designer.rb
@@ -1,0 +1,12 @@
+# coding: utf-8
+# Thu Oct 2 16:43:35 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/c4fb245 Delete affinity-designer.rb [Vítor Galvão]
+cask :v1 => 'affinity-designer' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://s3.amazonaws.com/affinity-beta/download/Affinity%20Designer%20Beta.dmg'
+  homepage 'https://affinity.serif.com/'
+  license :unknown
+
+  app 'Affinity Designer.app'
+end

--- a/Casks/amazon-cloud-player.rb
+++ b/Casks/amazon-cloud-player.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# Fri Jun 13 17:03:55 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/f1690d4 removed amazon cloud player [Vítor Galvão]
+cask :v1 => 'amazon-cloud-player' do
+  url 'https://images-na.ssl-images-amazon.com/images/G/01/digital/music/morpho/installers/AmazonCloudPlayerInstaller_108.dmg'
+  homepage 'https://www.amazon.com/gp/feature.html/ref=dm_mo_cpw_fb_lm?docId=1001067901'
+  version '1.08'
+  sha256 '1383ecd5a65fc794c4faca9b6f0b2df3265f3d7d391137940267d85811086c95'
+  installer :manual => 'Amazon Cloud Player Installer.app'
+end

--- a/Casks/bodega.rb
+++ b/Casks/bodega.rb
@@ -1,0 +1,12 @@
+# Thu Oct 16 02:38:24 2014 +0700 https://github.com/caskroom/homebrew-cask/commit/9694f52 Delete Bodega cask [Yegor Timoschenko]
+cask :v1 => 'bodega' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://downloads.appbodega.com.s3.amazonaws.com/bodega/latest/Bodega.zip'
+  appcast 'https://dev.appbodega.com/sparkle/appcast'
+  homepage 'http://appbodega.com/'
+  license :unknown
+
+  app 'Bodega.app'
+end

--- a/Casks/camino.rb
+++ b/Casks/camino.rb
@@ -1,0 +1,11 @@
+# coding: utf-8
+# Thu Sep 25 03:52:39 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/0e16dd2 Delete camino.rb [Vítor Galvão]
+cask :v1 => 'camino' do
+  version '2.1.2'
+  sha256 'e212aa2b68fb3fa1a63c5d74d570843fd5b432bfde29baeed6c5c4d73ad31b51'
+
+  url 'http://download.cdn.mozilla.net/pub/mozilla.org/camino/releases/en-US/Camino-2.1.2.dmg'
+  homepage 'http://caminobrowser.org/'
+
+  app 'Camino.app'
+end

--- a/Casks/clear.rb
+++ b/Casks/clear.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# Thu Jun 5 15:53:44 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/3578f3e Removed clear [Vítor Galvão]
+cask :v1 => 'clear' do
+  url 'http://realmacsoftware.com/redirects/clear/direct'
+  homepage 'http://realmacsoftware.com/clear'
+  version :latest
+  sha256 :no_check
+  app 'Clear.app'
+end

--- a/Casks/echofon.rb
+++ b/Casks/echofon.rb
@@ -1,0 +1,7 @@
+# coding: utf-8
+# Sat Dec 8 16:49:38 2012 +1300 https://github.com/caskroom/homebrew-cask/commit/4bd1543 Echofon is discontinued [Félix Saparelli]
+cask :v1 => 'echofon' do
+  url 'http://file.echofon.com/twitter/mac/bin/Echofon_1.5.8.dmg'
+  homepage 'http://www.echofon.com/'
+  version '1.5.8'
+end

--- a/Casks/eggscellent.rb
+++ b/Casks/eggscellent.rb
@@ -1,0 +1,8 @@
+# Fri Jun 28 21:25:01 2013 +0200 https://github.com/caskroom/homebrew-cask/commit/0d44e5e Removes Eggscellent cask [Robert Curth]
+cask :v1 => 'eggscellent' do
+  url 'http://eggscellent.s3.amazonaws.com/betas/Eggscellent_Beta2.zip'
+  homepage 'http://www.eggscellentapp.com/'
+  version 'beta2'
+  sha256 '0fee4fb819fc51541322d671c4a6ca2829137f9f'
+  app 'Eggscellent.app'
+end

--- a/Casks/enjoy.rb
+++ b/Casks/enjoy.rb
@@ -1,0 +1,8 @@
+# Tue Oct 8 08:56:54 2013 -0700 https://github.com/caskroom/homebrew-cask/commit/362d843 Remove Enjoy.app [Fernando Paredes]
+cask :v1 => 'enjoy' do
+  url 'http://abstractable.net/enjoy/enjoy.zip'
+  homepage 'http://abstractable.net/enjoy/'
+  version :latest
+  sha256 :no_check
+  app 'Enjoy.app'
+end

--- a/Casks/fuzzy-clock.rb
+++ b/Casks/fuzzy-clock.rb
@@ -1,0 +1,8 @@
+# Fri Jun 28 22:06:56 2013 +0200 https://github.com/caskroom/homebrew-cask/commit/5692792 Removes fuzzy-clock [Robert Curth]
+cask :v1 => 'fuzzy-clock' do
+  url 'http://www.objectpark.org/Releases/FuzzyClock-1-2-10.dmg'
+  homepage 'http://www.objectpark.org/FuzzyClock.html'
+  version '1.2.10'
+  sha256 'f4d49e5819d7af020f202e7561b15ae203be357b'
+  app 'FuzzyClock.app'
+end

--- a/Casks/gpsbabel.rb
+++ b/Casks/gpsbabel.rb
@@ -1,0 +1,26 @@
+# Sun Jun 15 17:45:09 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/5ac3217 GPSBabel cask removed [Radek Simko]
+cask :v1 => 'gpsbabel' do
+
+  module Utils
+    def self.get_token(unix_timestamp)
+      _hour_in_sec = 60 * 60
+      _constant = 1480813383
+
+      unix_hours = unix_timestamp / _hour_in_sec
+      token = _constant + unix_hours
+
+      token.to_s(16)
+    end
+  end
+
+  url 'http://www.gpsbabel.org/plan9.php',
+    :data => {
+      'dl' => 'GPSBabel-1.5.1.dmg',
+      'token' => Utils.get_token(Time.now.utc.to_i)
+    },
+    :using => :post
+  homepage 'http://www.gpsbabel.org'
+  version '1.5.1'
+  sha256 '042d50ee75a95ed41b5d2c3957cf7a83da21ab057a7754bf1bde720615f1473f'
+  app 'GPSBabelFE.app'
+end

--- a/Casks/hibari.rb
+++ b/Casks/hibari.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# Mon Mar 17 14:21:18 2014 +0000 https://github.com/caskroom/homebrew-cask/commit/8c64aaa removed hibari [Vítor Galvão]
+cask :v1 => 'hibari' do
+  url 'http://hibariapp.com/downloads/Hibari-latest.zip'
+  homepage 'http://hibariapp.com'
+  version :latest
+  sha256 :no_check
+  app 'Hibari.app'
+end

--- a/Casks/hockeycoach.rb
+++ b/Casks/hockeycoach.rb
@@ -1,0 +1,8 @@
+# Thu Mar 13 16:40:50 2014 -0700 https://github.com/caskroom/homebrew-cask/commit/e008f64 Remove Hockeycoach [Fernando Paredes]
+cask :v1 => 'hockeycoach' do
+  url 'http://download.hockeyapp.net/apps/HockeyCoach/HockeyCoach-1.0.2.zip'
+  homepage 'http://hockeyapp.net/releases/hockeycoach/'
+  version '1.0.2'
+  sha256 '423ef6c54dfe21f9fe6a34d6a1daafa86d6bcd9d26c89e0262112b2a9c78c893'
+  app 'HockeyCoach.app'
+end

--- a/Casks/instashare.rb
+++ b/Casks/instashare.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# Mon Sep 16 20:36:42 2013 +0100 https://github.com/caskroom/homebrew-cask/commit/6c759b0 removed instashare, since it's now an AppStore-only app [Vítor Galvão]
+cask :v1 => 'instashare' do
+  url 'http://instashareapp.com/files/InstashareB13.zip'
+  homepage 'http://instashareapp.com/'
+  version 'Beta 13'
+  sha256 '93f67131daaf6664d9d76a61b5115c7252fcc9ab'
+  app 'Instashare.app'
+end

--- a/Casks/less.rb
+++ b/Casks/less.rb
@@ -1,0 +1,11 @@
+# Mon Nov 10 10:31:07 2014 +0300 https://github.com/caskroom/homebrew-cask/commit/ff8ee8c Remove Less cask, app not available. [Vasily Kraev]
+cask :v1 => 'less' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://incident57.com/less/files/Less.zip'
+  homepage 'http://incident57.com/less/'
+  license :unknown
+
+  app 'Less.app'
+end

--- a/Casks/line.rb
+++ b/Casks/line.rb
@@ -1,0 +1,8 @@
+# Fri Nov 8 21:31:19 2013 -0800 https://github.com/caskroom/homebrew-cask/commit/e06539b Delete Line Messenger: Migrated to Mac App Store for all future updates. [Steven Hsu]
+cask :v1 => 'line' do
+  url 'http://dl.desktop.line.naver.jp/naver/LINE/osx/Line.dmg'
+  homepage 'http://line.naver.jp'
+  version :latest
+  sha256 :no_check
+  app 'Line.app'
+end

--- a/Casks/mangao.rb
+++ b/Casks/mangao.rb
@@ -1,0 +1,10 @@
+# Wed Aug 27 12:40:41 2014 +0200 https://github.com/caskroom/homebrew-cask/commit/387dd6f Remove Mangao [ndr]
+cask :v1 => 'mangao' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://dl.dropboxusercontent.com/u/262366138/mangao/Mangao.app.zip'
+  homepage 'http://ryotaminami93.appspot.com/mangao.html'
+
+  app 'Mangao.app'
+end

--- a/Casks/mirage.rb
+++ b/Casks/mirage.rb
@@ -1,0 +1,8 @@
+# Wed Oct 2 15:08:40 2013 -0700 https://github.com/caskroom/homebrew-cask/commit/dc0a49d Remove Mirage [Fernando Paredes]
+cask :v1 => 'mirage' do
+  url 'http://cl.ly/1agC/download/Mirage%20101.zip'
+  homepage 'http://mac.softpedia.com/get/Wallpapers/Ferber-Mirage.shtml'
+  version :latest
+  sha256 :no_check
+  app 'Mirage.app'
+end

--- a/Casks/mkvtoolnix.rb
+++ b/Casks/mkvtoolnix.rb
@@ -1,0 +1,12 @@
+# Mon Oct 6 15:44:11 2014 -0500 https://github.com/caskroom/homebrew-cask/commit/51d2a84 remove mkvtoolnix 7.2.0, only user-built binaries available [Johnathan Conley]
+cask :v1 => 'mkvtoolnix' do
+  version '7.1.0'
+  sha256 '33a26c756b4763c781913b2db20a1419d530aad6919e63b4f4aa931f442e2310'
+
+  url "http://www.fosshub.com/download/Mkvtoolnix-#{version}.dmg",
+      :referer => 'http://www.fosshub.com/MKVToolNix.html'
+  homepage 'http://www.bunkus.org/videotools/mkvtoolnix/'
+  license :unknown
+
+  app "Mkvtoolnix-#{version}.app"
+end

--- a/Casks/monochrome.rb
+++ b/Casks/monochrome.rb
@@ -1,0 +1,12 @@
+# coding: utf-8
+# Thu Oct 9 16:05:33 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/298048b Delete monochrome.rb [Vítor Galvão]
+cask :v1 => 'monochrome' do
+  version '3.3'
+  sha256 '2eaec5156ba7f55ac0afa2e9777f0800da756831e4b66a2e9c2c466154177057'
+
+  url "https://dl.dropboxusercontent.com/u/63362/monochrome_#{version.gsub('.', '_')}.zip"
+  homepage 'http://lucianmarin.com/monochrome/'
+  license :unknown
+
+  app 'Monochrome.app'
+end

--- a/Casks/musicmanager.rb
+++ b/Casks/musicmanager.rb
@@ -1,0 +1,8 @@
+# Thu May 8 15:05:05 2014 -0700 https://github.com/caskroom/homebrew-cask/commit/7c53279 Upgrade Google's Music Manager.app to 1.0.104.6528 [ninjabong]
+cask :v1 => 'musicmanager' do
+  url 'https://dl.google.com/dl/androidjumper/mac/718015/musicmanager.dmg'
+  homepage 'https://music.google.com'
+  version '1.0.71.8015'
+  sha256 '16f93db5f672313fb3da66b3abbaf4408a136cc677a00851d5cf7221d76c25a5'
+  app 'MusicManager.app'
+end

--- a/Casks/osirix.rb
+++ b/Casks/osirix.rb
@@ -1,0 +1,12 @@
+# coding: utf-8
+# Wed Nov 12 20:13:32 2014 +0000 https://github.com/caskroom/homebrew-cask/commit/93cae3f removed osirix [Vítor Galvão]
+cask :v1 => 'osirix' do
+  version '5.9'
+  sha256 '64f6a8bc5614da55002daf618c96b1d52408a43e3b2973c0b209a81a91526758'
+
+  url "http://www.osirix-viewer.com/OsiriX#{version}.dmg"
+  homepage 'http://www.osirix-viewer.com'
+  license :unknown
+
+  app 'osirix.app'
+end

--- a/Casks/pandorajam.rb
+++ b/Casks/pandorajam.rb
@@ -1,0 +1,8 @@
+# Tue Nov 12 15:21:06 2013 -0600 https://github.com/caskroom/homebrew-cask/commit/5a983fd Delete PandoraJam [Joel Kuzmarski]
+cask :v1 => 'pandorajam' do
+  url 'http://www.bitcartel.com/downloads/pandorajam.zip'
+  homepage 'http://www.bitcartel.com/pandorajam/'
+  version :latest
+  sha256 :no_check
+  app 'PandoraJam.app'
+end

--- a/Casks/pixen.rb
+++ b/Casks/pixen.rb
@@ -1,0 +1,8 @@
+# Tue Oct 8 09:15:16 2013 -0700 https://github.com/caskroom/homebrew-cask/commit/23c45b0 Remove Pixen [Fernando Paredes]
+cask :v1 => 'pixen' do
+  url 'http://www.mattrajca.com/assets/files/Pixen_3_5_10b1.zip'
+  homepage 'http://pixenapp.com/'
+  version '3.5.10b1'
+  sha256 'a2a0f9be3e658abbe551db2250cc0d152977d2c1'
+  app 'Pixen.app'
+end

--- a/Casks/reeder.rb
+++ b/Casks/reeder.rb
@@ -1,0 +1,8 @@
+# Tue Jun 17 18:41:20 2014 +0800 https://github.com/caskroom/homebrew-cask/commit/ef7887c Delete reeder.rb [Zili Yin]
+cask :v1 => 'reeder' do
+  url 'http://reederapp.com/beta-reeder-for-mac/Reeder2.0b7.zip'
+  homepage 'http://reederapp.com/mac/'
+  version '2.0b7'
+  sha256 '6778fe2747d907e153666c01b3ee8700ed31b05e128c8433fb24f429a62dfdd2'
+  app 'Reeder.app'
+end

--- a/Casks/repast.rb
+++ b/Casks/repast.rb
@@ -1,0 +1,8 @@
+# Fri May 31 16:33:07 2013 +0800 https://github.com/caskroom/homebrew-cask/commit/4bb0733 Add anki cask [ouyang]
+cask :v1 => 'repast' do
+  url 'http://jaist.dl.sourceforge.net/project/repast/Repast%20Simphony/Repast%20Simphony%202.0/Repast%20Simphony%202.0%2032.dmg'
+  homepage 'http://repast.sourceforge.net/'
+  version '3.7.1'
+  sha256 'f0189769f54ec627685f8b90478ff427e49321fb'
+  app 'Repast-Simphony-2.0/Repast Simphony.app'
+end

--- a/Casks/skii.rb
+++ b/Casks/skii.rb
@@ -1,0 +1,10 @@
+# Thu Oct 9 08:31:49 2014 -0400 https://github.com/caskroom/homebrew-cask/commit/885c9fe remove abandoned skii.rb [Roland Walker]
+cask :v1 => 'skii' do
+  version '2.1.6.1'
+  sha256 'f523b9a7f58592103529813a79d95424f8025e8d0c033d6d32cb4f355aecc63a'
+
+  url "http://f.cl.ly/items/1C0f162Q0l450s0F2H26/Skii_#{version}.dmg"
+  homepage 'https://www.macupdate.com/app/mac/36677/skii'
+
+  app 'Skii.app'
+end

--- a/Casks/speed-download.rb
+++ b/Casks/speed-download.rb
@@ -1,0 +1,9 @@
+# Sat Feb 22 16:50:38 2014 -0500 https://github.com/caskroom/homebrew-cask/commit/1b1aeb2 remove discontinued app Speed Download [Roland Walker]
+cask :v1 => 'speed-download' do
+  url 'http://mirror.nscocoa.com/~yazsoftc1/files/sd5/sd5.zip'
+  homepage 'http://www.yazsoft.com/products/speed-download'
+  version :latest
+  sha256 :no_check
+  container :nested => 'Speed Download 5.dmg'
+  app 'Speed Download 5/Speed Download.app'
+end

--- a/Casks/spirited-away.rb
+++ b/Casks/spirited-away.rb
@@ -1,0 +1,11 @@
+# Wed Sep 24 04:47:26 2014 +0200 https://github.com/caskroom/homebrew-cask/commit/f0a8dcf Remove Spirited Away [ndr]
+cask :v1 => 'spirited-away' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://dl.dropbox.com/u/1025/spiritedaway/Spirited%20Away.zip'
+  appcast 'http://files.getdropbox.com/u/1025/spiritedaway/spiritedaway.xml'
+  homepage 'http://drikin.com/2010/11/spirited-away.html'
+
+  app 'Spirited Away.app'
+end

--- a/Casks/textual.rb
+++ b/Casks/textual.rb
@@ -1,0 +1,8 @@
+# Sat Sep 21 19:17:11 2013 +0200 https://github.com/caskroom/homebrew-cask/commit/6269d23 Remove textual demo [Adam Stankiewicz]
+cask :v1 => 'textual' do
+  url 'http://www.codeux.com/textual/private/downloads/builds/Textual_Demo_12536.zip'
+  homepage 'http://www.codeux.com/textual/'
+  version '2.1.1'
+  sha256 'af057d11e3578afa3b80f4f26093978389982ca2'
+  app 'Textual.app'
+end

--- a/Casks/wunderlist.rb
+++ b/Casks/wunderlist.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# Sat Apr 5 17:54:03 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/3773bd4 removed wunderlist [Vítor Galvão]
+cask :v1 => 'wunderlist' do
+  url 'https://www.macupdate.com/download/35862/Wunderlist.zip'
+  homepage 'https://www.wunderlist.com/en/'
+  version '2.3.2'
+  sha256 'd7adf0cb3b9ab0cd4265ccc7c1e757cd38e74dbcf8c56017baf443dd2abec1b8'
+  app 'Wunderlist.app'
+end

--- a/Casks/yanvi.rb
+++ b/Casks/yanvi.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# Sat Apr 12 21:02:18 2014 +0100 https://github.com/caskroom/homebrew-cask/commit/4378dd3 Remove YANVI [Vítor Galvão]
+cask :v1 => 'yanvi' do
+  url 'http://download1167.mediafire.com/2ve2xmcd85ug/iy2s1yp233pzj80/Yet_Another_NFO_Viewer_v1.0.2.dmg'
+  homepage 'https://www.macupdate.com/app/mac/39748/yet-another-nfo-viewer'
+  version '1.0.2'
+  sha256 '7e7db828e404d1594ca847c4ccbb4fe7924dd5d3a116e69ddef94884345749ed'
+  app 'YaNvi.app'
+end


### PR DESCRIPTION
The set of all deleted Casks from the main repo turned out to be quite small, after removing false positives such as splits, merges, renames, and repo transfers, so I pushed them all in this PR.

This is a very rough cut; the set might still be too inclusive, but that shouldn't matter much given the purpose of this repo.

A quick, imperfect attempt was made to bring older Casks up to DSL 1.0.

Comments were added to each Cask, with a reference to the deletion event in the main repo.